### PR TITLE
Support alternative homebrew locations

### DIFF
--- a/xdebug
+++ b/xdebug
@@ -6,7 +6,7 @@ command="$1"
 php_version_dot=$(php -r "\$v=explode('.', phpversion() ); echo implode('.', array_splice(\$v, 0, -1));")
 php_version="${php_version_dot//./}"
 
-xdebug_conf_path="/usr/local/etc/php/$php_version_dot/conf.d"
+xdebug_conf_path="$(brew --prefix)/etc/php/$php_version_dot/conf.d"
 xdebug_conf_file="ext-xdebug.ini"
 xdebug_conf=$xdebug_conf_path/$xdebug_conf_file
 


### PR DESCRIPTION
I use homebrew with [boxen](https://github.com/boxen/our-boxen/) and boxen installs homebrew to ``/opt/boxen/homebrew``. Homebrew has handy command to determine the install location.