### PR TITLE
Use php@version as service name

### DIFF
--- a/xdebug-toggle
+++ b/xdebug-toggle
@@ -73,7 +73,7 @@ if [ ! -f "$extension_dir"/xdebug.so ]; then
                     echo ""
                     echo "Xdebug has been $STATUS, restarting $SERVER_NAME"
 
-                    brew services restart php"${php_version}"
+                    brew services restart php@"${php_version_dot}"
                 else
                     echo ""
                     echo "Xdebug has been $STATUS, restarting $SERVER_NAME (it might ask for your password)"


### PR DESCRIPTION
homebrew has a new naming scheme for the php formulas. See https://github.com/Homebrew/homebrew-core/blob/master/Formula/php@7.2.rb for example.