### PR TITLE
Fix compatibility with Apple M1

### DIFF
--- a/xdebug-toggle
+++ b/xdebug-toggle
@@ -50,7 +50,7 @@ if [ ! -f "$extension_dir"/xdebug.so ]; then
                 STATUS="disabled"
             fi
 
-            current_stable_php_path="/usr/local/opt/php/bin/php"
+            current_stable_php_path="$(brew --prefix php)/bin/php"
             if [ -f $(eval echo ${current_stable_php_path}) ]; then
                 current_stable_php_version=$(${current_stable_php_path} -r "\$v=explode('.', PHP_VERSION ); echo implode('.', array_splice(\$v, 0, -1));")
             fi


### PR DESCRIPTION
homebrew uses a different path on Mac with M1 (or arm) processors. ``brew --prefix`` should work both cases.