### PR TITLE
bypass xdebug when getting php version

### DIFF
--- a/xdebug-toggle
+++ b/xdebug-toggle
@@ -8,7 +8,7 @@
 app="$(basename "$0")"
 command="$1"
 options="$2"
-php_version_dot=$(php -r "\$v=explode('.', PHP_VERSION ); echo implode('.', array_splice(\$v, 0, -1));")
+php_version_dot=$(php -dxdebug.mode=off -r "\$v=explode('.', PHP_VERSION ); echo implode('.', array_splice(\$v, 0, -1));")
 php_version="${php_version_dot//./}"
 
 xdebug_conf_path="$(brew --prefix)/etc/php/$php_version_dot/conf.d"


### PR DESCRIPTION
on latest versions of php/xdebug, the "xdebug off" command was being debugged itself